### PR TITLE
Handle debug logging correctly

### DIFF
--- a/src/Svrooij.PowerShell.DI/PowerShellGenerator.cs
+++ b/src/Svrooij.PowerShell.DI/PowerShellGenerator.cs
@@ -15,7 +15,8 @@ public class PowerShellGenerator : IIncrementalGenerator
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Create the code files in the project (so you don't have to include an additional DLL)
-        context.RegisterPostInitializationOutput(static ctx => {
+        context.RegisterPostInitializationOutput(static ctx =>
+        {
             ctx.AddSource("Attributes.g.cs", SourceGenerationHelper.Attributes);
             ctx.AddSource("Logging.g.cs", LoggingClasses.Classes);
             ctx.AddSource("ThreadAffinitiveSynchronizationContext.g.cs", ThreadSynchronisation.ThreadAffinitiveSynchronizationContext);
@@ -94,12 +95,12 @@ public class PowerShellGenerator : IIncrementalGenerator
                 f.Required
                 )).ToImmutableArray();
 
-            return new BindingToGenerate(
-                classDeclarationSyntax.BaseList!.Types[0].ToString(),
-                classDeclarationSyntax.Identifier.ToString(),
-                @namespace ?? "oops",
-                fields);
-            //fields.ToImmutableArray());
+        return new BindingToGenerate(
+            classDeclarationSyntax.BaseList!.Types[0].ToString(),
+            classDeclarationSyntax.Identifier.ToString(),
+            @namespace ?? "oops",
+            fields);
+        //fields.ToImmutableArray());
     }
 
     private static void Execute(Compilation compilation, ImmutableArray<BindingToGenerate?> classes, SourceProductionContext context)
@@ -147,7 +148,7 @@ public class PowerShellGenerator : IIncrementalGenerator
                     $"                {property.PropertyName} = serviceProvider.GetService<{property.PropertyType}>();");
             }
         }
-        
+
         sourceBuilder.AppendLine("            };");
         sourceBuilder.AppendLine("    }");
         sourceBuilder.AppendLine("}");

--- a/src/Svrooij.PowerShell.DI/SourceGeneratorHelper.cs
+++ b/src/Svrooij.PowerShell.DI/SourceGeneratorHelper.cs
@@ -2,7 +2,7 @@
 
 internal class SourceGenerationHelper
 {
-internal const string Attributes = @"using System;
+    internal const string Attributes = @"using System;
 namespace Svrooij.PowerShell.DI
 {
     /// <summary>
@@ -28,7 +28,7 @@ namespace Svrooij.PowerShell.DI
     }
 }";
 
-internal const string Classes = @"
+    internal const string Classes = @"
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Concurrent;


### PR DESCRIPTION
You could not get debug logging to work with the previous version. This will allow you to display debug logs as long as you configure the minimum log level for that exact method to the `Debug` level